### PR TITLE
Added current gen instances

### DIFF
--- a/templates/cloud9-ide-master.template.yaml
+++ b/templates/cloud9-ide-master.template.yaml
@@ -122,24 +122,49 @@ Parameters:
     Type: String
     Default: t2.micro
     AllowedValues:
+    - t2.nano
     - t2.micro
     - t2.small
-    - m4.large
-    - t2.nano
-    - c4.large
     - t2.medium
     - t2.large
-    - m4.xlarge
     - t2.xlarge
-    - c4.xlarge
-    - c4.2xlarge
-    - m4.2xlarge
     - t2.2xlarge
-    - c4.4xlarge
+    - t3.nano
+    - t3.micro
+    - t3.small
+    - t3.medium
+    - t3.large
+    - t3.xlarge
+    - t3.2xlarge
+    - m4.large
+    - m4.xlarge
+    - m4.2xlarge
     - m4.4xlarge
-    - c4.8xlarge
     - m4.10xlarge
     - m4.16xlarge
+    - m5.large
+    - m5.xlarge
+    - m5.2xlarge
+    - m5.4xlarge
+    - m5.8xlarge
+    - m5.12xlarge
+    - m5.16xlarge
+    - m5.24xlarge
+    - m5.metal
+    - c4.large
+    - c4.xlarge
+    - c4.2xlarge
+    - c4.4xlarge
+    - c4.8xlarge
+    - c5.large
+    - c5.xlarge
+    - c5.2xlarge
+    - c5.4xlarge
+    - c5.9xlarge
+    - c5.12xlarge
+    - c5.18xlarge
+    - c5.24xlarge
+    - c5.metal
   C9StopTime:
     Description: The number of minutes until the running instance is shut down after
       the environment has last been used.


### PR DESCRIPTION
Used the Cloud9 Console to see which Instances were supported. I left the old instances because the console still lists them and I don't want to break backwards compatibility. Also, reorganized the instances according to instance type and family to make it easier to find instances.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
