### PR TITLE
Feature disable nat

### DIFF
--- a/templates/cloud9-ide-master.template.yaml
+++ b/templates/cloud9-ide-master.template.yaml
@@ -451,6 +451,7 @@ Resources:
         PublicSubnet1CIDR: !Ref PublicSubnet1CIDR
         PublicSubnet2CIDR: !Ref PublicSubnet2CIDR
         NumberOfAZs: !Ref NumberOfAZs
+        CreateNATGateways: 'true'
   IDEStack:
     Type: AWS::CloudFormation::Stack
     Properties:

--- a/templates/cloud9-ide-master.template.yaml
+++ b/templates/cloud9-ide-master.template.yaml
@@ -193,7 +193,7 @@ Parameters:
   EBSVolumeSize:
     Description: The desired size (in GB) of the Amazon EBS volume for your Cloud9 IDE.
     Type: Number
-    Default: 16
+    Default: 100
   EnableBastionStack:
     AllowedValues: ['true', 'false']
     Default: 'false'

--- a/templates/cloud9-ide-master.template.yaml
+++ b/templates/cloud9-ide-master.template.yaml
@@ -10,6 +10,7 @@ Metadata:
         Parameters:
           - AvailabilityZones
           - NumberOfAZs
+          - CreateNATGateways
           - PrivateSubnet1CIDR
           - PrivateSubnet2CIDR
           - PublicSubnet1CIDR
@@ -49,6 +50,8 @@ Metadata:
         default: Stop time
       NumberOfAZs:
         default: Number of Availability Zones
+      CreateNATGateways:
+        default: Enable NAT gateway for private subnets to have outbound internat access.
       PrivateSubnet1CIDR:
         default: Private subnet 1 CIDR
       PrivateSubnet2CIDR:
@@ -190,7 +193,7 @@ Parameters:
   EBSVolumeSize:
     Description: The desired size (in GB) of the Amazon EBS volume for your Cloud9 IDE.
     Type: Number
-    Default: 100
+    Default: 16
   EnableBastionStack:
     AllowedValues: ['true', 'false']
     Default: 'false'
@@ -204,6 +207,11 @@ Parameters:
       - 2
       - 3
       - 4
+  CreateNATGateways:
+    AllowedValues: ['true', 'false']
+    Default: 'true'
+    Description: (Optional) Choose false to disable NAT gateways for the private subnets.
+    Type: String
   OwnerArn:
     Description: 
       The Amazon Resource Name (ARN) of the environment owner. This ARN can be the 
@@ -437,7 +445,7 @@ Resources:
     Properties:
       TemplateURL:
         !Sub 
-          - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-aws-vpc/templates/aws-vpc.template'
+          - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-aws-vpc/templates/aws-vpc.template.yaml'
           - S3Region: !If [UsingDefaultBucket, !Sub '${AWS::Region}', !Ref QSS3BucketRegion]
             S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:
@@ -451,7 +459,7 @@ Resources:
         PublicSubnet1CIDR: !Ref PublicSubnet1CIDR
         PublicSubnet2CIDR: !Ref PublicSubnet2CIDR
         NumberOfAZs: !Ref NumberOfAZs
-        CreateNATGateways: 'true'
+        CreateNATGateways: !Ref CreateNATGateways
   IDEStack:
     Type: AWS::CloudFormation::Stack
     Properties:


### PR DESCRIPTION
*Issue #, if available:*
#37

*Description of changes:*
Whilst I'm not sure if its possible to shutdown instances from cloudformation, it is possible to disable the NAT gateway, which has a significant cost if it isn't required, or only required during instance usage.  In any case since the cloud9 instance is launched in a public subnet, enabling the NAT gateway is not cost efficient if the user has no intention of placing resources into the private subnet of this cloudformation deployment.  This change allows users to optionally disable the NAT gateway.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
