### PR TITLE
change python 3.6 to 3.9

### DIFF
--- a/templates/cloud9-ide-master.template.yaml
+++ b/templates/cloud9-ide-master.template.yaml
@@ -253,7 +253,7 @@ Resources:
     Properties:
       Description: Gets 3 availability zone names from the region the lambda is launched in.
       Handler: index.handler
-      Runtime: python3.6
+      Runtime: python3.9
       Role: !GetAtt 'GetAzsRole.Arn'
       Timeout: 300
       Code:
@@ -307,7 +307,7 @@ Resources:
     Properties:
       Description: Creates a keypair and stores private key in SSM parameter store.
       Handler: index.handler
-      Runtime: python3.6
+      Runtime: python3.9
       Role: !GetAtt 'CreateKeypairRole.Arn'
       Timeout: 300
       Code:
@@ -378,7 +378,7 @@ Resources:
     Properties:
       Description: Creates a keypair and stores private key in SSM parameter store.
       Handler: index.handler
-      Runtime: python3.6
+      Runtime: python3.9
       Role: !GetAtt 'GetIpRole.Arn'
       Timeout: 900
       Code:


### PR DESCRIPTION
I deploy this file in cloudformation and i was receiving an error with the python version, so I changed it from python 3.6 to python 3.9 version. I ran this template in AWS cloudformation and python errors were fixed but I receive this new error: The following resource(s) failed to create: [CopyZipsFunction].

I would like to receive some help to solve the error

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
